### PR TITLE
Use another bits when depth buffer cannot be 32 bits.

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -15,12 +15,24 @@ use units::{Nemo, Minion, MinionController};
 #[allow(dead_code)]
 fn main() {
     use glium::DisplayBuild;
-    let display = glium::glutin::WindowBuilder::new()
-        .with_dimensions(1024, 768)
-        .with_depth_buffer(32)
-        .with_title(common::PROJECT_NAME.to_string())
-        .build_glium().unwrap();
 
+    let depth_bits_candidates: [u8; 3] = [ 32, 24, 16 ];
+    fn build_display(depth_size: u8) -> Option<glium::backend::glutin_backend::GlutinFacade> {
+        glium::glutin::WindowBuilder::new()
+            .with_dimensions(1024, 768)
+            .with_depth_buffer(depth_size)
+            .with_title(common::PROJECT_NAME.to_string())
+            .build_glium().ok()
+    }
+    let display = (|| -> Option<glium::backend::glutin_backend::GlutinFacade> {
+        for depth_bits in depth_bits_candidates.iter() {
+            match build_display(*depth_bits) {
+                Some(display) => return Some(display),
+                None => continue
+            }
+        }
+        None
+    })().unwrap();
 
     //
     // Basics


### PR DESCRIPTION
지금 구현은 32bits으로 depth buffer가 고정 되어 있다.
32bits을 사용하지 못하는 경우 24 bit, 16 bit을 시도하도록 수정하였다.

build_display 함수가 Result가 아닌 Option을 리턴하는 이유는, build_glium 함수가 리턴하는 타입이

`````` rust
Result<glium::backend::glutin_backend::GlutinFacade, glium::GliumCreationError<glutin::CreationError>>```
인데, 저 인자에 들어가는 glutin::CreationError를 사용할 방법을 몰라서 일단 에러 부분을 버림.
build_display가 Result를 리턴하도록 하고, 에러에 따라 다른 처리를 하는 것은 패치 올리고 이슈로 등록할 계획.
``````
