### PR TITLE
실행속도 향상

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -2,10 +2,12 @@
 name = "client"
 version = "0.0.1"
 dependencies = [
+ "bincode 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.0.1",
  "glium 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "obj-rs 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmath 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -23,6 +25,17 @@ dependencies = [
 name = "android_glue"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bincode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -265,6 +278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "obj-rs"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +328,14 @@ dependencies = [
 name = "rustc-serialize"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shared_library"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,6 +3,7 @@
 name = "client"
 version = "0.0.1"
 authors = ["Hyeon Kim <simnalamburt@gmail.com>"]
+build = "build.rs"
 
 [dependencies]
 common = { path = "../common" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,3 +12,9 @@ xmath = { version = "0.2.2", features = ["glium-support"] }
 glium = { version = "0.8.2", default-features = false, features = ["glutin"] }
 rand = "0.3.9"
 obj-rs = { version = "0.4.12", features = ["glium-support"] }
+bincode = "0.4"
+
+[build-dependencies]
+obj-rs = { version = "0.4.12", features = ["glium-support"] }
+rustc-serialize = "0.3"
+bincode = "0.4"

--- a/client/build.rs
+++ b/client/build.rs
@@ -1,0 +1,12 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("rilakkuma.obj.json");
+    let mut f = File::create(&dest_path).unwrap();
+
+    f.write_all(b">_<").unwrap();
+}

--- a/client/build.rs
+++ b/client/build.rs
@@ -1,12 +1,39 @@
+extern crate obj;
+extern crate rustc_serialize;
+extern crate bincode;
+
 use std::env;
 use std::fs::File;
-use std::io::Write;
+use std::io::BufReader;
 use std::path::Path;
+use std::env::current_exe;
+use obj::{Obj, load_obj};
+use bincode::rustc_serialize as bcode;
+use bincode::SizeLimit;
 
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let dest_path = Path::new(&out_dir).join("rilakkuma.obj.json");
-    let mut f = File::create(&dest_path).unwrap();
+    // As of rust 1.2, `current_exe()` of build script looks like below:
+    //
+    //     /fate/client/target/debug/build/client-057d32d9862c7834/build-script-build
+    //
+    // So `current_exe()/../../../../../res` will return desired resource's path
+    let mut src = current_exe().unwrap();
+    src.pop();
+    src.pop();
+    src.pop();
+    src.pop();
+    src.pop();
+    src.push("res");
+    src.push("rilakkuma.obj");
 
-    f.write_all(b">_<").unwrap();
+    // Parse rilakkuma
+    let input = BufReader::new(File::open(src).unwrap());
+    let rilakkuma: Obj = load_obj(input).unwrap();
+
+    // Serialize rilakkuma
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("rilakkuma.obj.bin");
+    let mut output = File::create(&dest).unwrap();
+
+    bcode::encode_into(&rilakkuma, &mut output, SizeLimit::Infinite).unwrap();
 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -1,7 +1,7 @@
 use std::io;
 use glium::{vertex, index, texture};
 use glium::program::ProgramCreationError;
-use obj::ObjError;
+use bincode::rustc_serialize::DecodingError;
 
 #[derive(Debug)]
 pub enum CreationError {
@@ -9,7 +9,7 @@ pub enum CreationError {
     VertexBufferCreationError(vertex::BufferCreationError),
     IndexBufferCreationError(index::BufferCreationError),
     ProgramCreationError(ProgramCreationError),
-    ObjError(ObjError),
+    DecodingError(DecodingError),
 }
 
 macro_rules! implmnt {
@@ -28,7 +28,7 @@ implmnt!(IoError, io::Error);
 implmnt!(VertexBufferCreationError, vertex::BufferCreationError);
 implmnt!(IndexBufferCreationError, index::BufferCreationError);
 implmnt!(ProgramCreationError);
-implmnt!(ObjError);
+implmnt!(DecodingError);
 
 #[derive(Debug)]
 pub enum DrawContextCreationError {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -17,7 +17,6 @@ use draw_context::DrawContext;
 use time::PreciseTime;
 use units::{Nemo, Minion, MinionController};
 use ui::UI;
-use resource::ResourceManager;
 
 #[cfg_attr(test, allow(dead_code))]
 fn main() {
@@ -50,9 +49,7 @@ fn main() {
     //
     // Game
     //
-    let mut resource_manager = ResourceManager::new();
-
-    let mut nemo = Nemo::new(&display, &mut resource_manager).unwrap();
+    let mut nemo = Nemo::new(&display).unwrap();
     let mut minions = vec![
         Minion::new(&display, (-17.0, 4.0)).unwrap(),
         Minion::new(&display, (-19.0, 2.0)).unwrap(),

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,6 +4,7 @@ extern crate xmath;
 #[macro_use] extern crate glium;
 extern crate rand;
 extern crate obj;
+extern crate bincode;
 
 mod draw_context;
 mod traits;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -16,6 +16,7 @@ use draw_context::DrawContext;
 use time::PreciseTime;
 use units::{Nemo, Minion, MinionController};
 use ui::UI;
+use resource::ResourceManager;
 
 #[cfg_attr(test, allow(dead_code))]
 fn main() {
@@ -48,7 +49,9 @@ fn main() {
     //
     // Game
     //
-    let mut nemo = Nemo::new(&display).unwrap();
+    let mut resource_manager = ResourceManager::new();
+
+    let mut nemo = Nemo::new(&display, &mut resource_manager).unwrap();
     let mut minions = vec![
         Minion::new(&display, (-17.0, 4.0)).unwrap(),
         Minion::new(&display, (-19.0, 2.0)).unwrap(),

--- a/client/src/resource.rs
+++ b/client/src/resource.rs
@@ -3,18 +3,26 @@ use std::io::Result;
 use std::env::current_exe;
 use std::fs::File;
 
-pub fn load<T: AsRef<Path>>(name: T) -> Result<File> {
-    // During development, resources are located in `./client/res/*` and
-    // the binary is located in `./client/target/{debug, release}/client.exe`.
-    //
-    // `(file path of binary)/../../../res/(name)` will return desired
-    // resource's path
-    let mut path = current_exe().unwrap();
-    path.pop();
-    path.pop();
-    path.pop();
-    path.push("res");
-    path.push(name);
+pub struct ResourceManager;
 
-    File::open(path)
+impl ResourceManager {
+    pub fn new() -> Self {
+        ResourceManager
+    }
+
+    pub fn load<T: AsRef<Path>>(&mut self, name: T) -> Result<File> {
+        // During development, resources are located in `./client/res/*` and
+        // the binary is located in `./client/target/{debug, release}/client.exe`.
+        //
+        // `(file path of binary)/../../../res/(name)` will return desired
+        // resource's path
+        let mut path = current_exe().unwrap();
+        path.pop();
+        path.pop();
+        path.pop();
+        path.push("res");
+        path.push(name);
+
+        File::open(path)
+    }
 }

--- a/client/src/resource.rs
+++ b/client/src/resource.rs
@@ -4,21 +4,13 @@ use obj::Obj;
 use bincode::SizeLimit;
 use bincode::rustc_serialize::{decode_from, DecodingResult};
 
-pub struct ResourceManager;
+pub fn load_obj<T: AsRef<Path>>(name: T) -> DecodingResult<Obj> {
+    let mut path = PathBuf::new();
+    path.push(env!("OUT_DIR"));
+    path.push(name);
+    path.set_extension("obj.bin");
 
-impl ResourceManager {
-    pub fn new() -> Self {
-        ResourceManager
-    }
-
-    pub fn load_obj<T: AsRef<Path>>(&mut self, name: T) -> DecodingResult<Obj> {
-        let mut path = PathBuf::new();
-        path.push(env!("OUT_DIR"));
-        path.push(name);
-        path.set_extension("obj.bin");
-
-        let mut input = try!(File::open(path));
-        let decoded: Obj = try!(decode_from(&mut input, SizeLimit::Infinite));
-        Ok(decoded)
-    }
+    let mut input = try!(File::open(path));
+    let decoded: Obj = try!(decode_from(&mut input, SizeLimit::Infinite));
+    Ok(decoded)
 }

--- a/client/src/resource.rs
+++ b/client/src/resource.rs
@@ -1,7 +1,8 @@
-use std::path::Path;
-use std::io::Result;
-use std::env::current_exe;
+use std::path::{Path, PathBuf};
 use std::fs::File;
+use obj::Obj;
+use bincode::SizeLimit;
+use bincode::rustc_serialize::{decode_from, DecodingResult};
 
 pub struct ResourceManager;
 
@@ -10,19 +11,14 @@ impl ResourceManager {
         ResourceManager
     }
 
-    pub fn load<T: AsRef<Path>>(&mut self, name: T) -> Result<File> {
-        // During development, resources are located in `./client/res/*` and
-        // the binary is located in `./client/target/{debug, release}/client.exe`.
-        //
-        // `(file path of binary)/../../../res/(name)` will return desired
-        // resource's path
-        let mut path = current_exe().unwrap();
-        path.pop();
-        path.pop();
-        path.pop();
-        path.push("res");
+    pub fn load_obj<T: AsRef<Path>>(&mut self, name: T) -> DecodingResult<Obj> {
+        let mut path = PathBuf::new();
+        path.push(env!("OUT_DIR"));
         path.push(name);
+        path.set_extension("obj.bin");
 
-        File::open(path)
+        let mut input = try!(File::open(path));
+        let decoded: Obj = try!(decode_from(&mut input, SizeLimit::Infinite));
+        Ok(decoded)
     }
 }

--- a/client/src/units/nemo.rs
+++ b/client/src/units/nemo.rs
@@ -4,7 +4,7 @@ use glium::backend::Facade;
 use glium::framebuffer::SimpleFrameBuffer;
 use traits::{Object, Move};
 use error::CreationError;
-use resource::ResourceManager;
+use resource::load_obj;
 use super::Unit;
 
 pub struct Nemo {
@@ -22,8 +22,8 @@ enum State {
 }
 
 impl Nemo {
-    pub fn new<F: Facade>(facade: &F, rm: &mut ResourceManager) -> Result<Self, CreationError> {
-        let bear = try!(rm.load_obj("rilakkuma"));
+    pub fn new<F: Facade>(facade: &F) -> Result<Self, CreationError> {
+        let bear = try!(load_obj("rilakkuma"));
 
         let unit = try!(Unit::new(
             facade,

--- a/client/src/units/nemo.rs
+++ b/client/src/units/nemo.rs
@@ -6,7 +6,7 @@ use glium::framebuffer::SimpleFrameBuffer;
 use obj::load_obj;
 use traits::{Object, Move};
 use error::CreationError;
-use resource::load;
+use resource::ResourceManager;
 use super::Unit;
 
 pub struct Nemo {
@@ -24,8 +24,8 @@ enum State {
 }
 
 impl Nemo {
-    pub fn new<F: Facade>(facade: &F) -> Result<Self, CreationError> {
-        let bear = try!(load("rilakkuma.obj"));
+    pub fn new<F: Facade>(facade: &F, rm: &mut ResourceManager) -> Result<Self, CreationError> {
+        let bear = try!(rm.load("rilakkuma.obj"));
         let bear = BufReader::new(bear);
         let bear = try!(load_obj(bear));
 

--- a/client/src/units/nemo.rs
+++ b/client/src/units/nemo.rs
@@ -1,9 +1,7 @@
 use draw_context::DrawContext;
-use std::io::BufReader;
 use glium::{Frame, DrawError};
 use glium::backend::Facade;
 use glium::framebuffer::SimpleFrameBuffer;
-use obj::load_obj;
 use traits::{Object, Move};
 use error::CreationError;
 use resource::ResourceManager;
@@ -25,9 +23,7 @@ enum State {
 
 impl Nemo {
     pub fn new<F: Facade>(facade: &F, rm: &mut ResourceManager) -> Result<Self, CreationError> {
-        let bear = try!(rm.load("rilakkuma.obj"));
-        let bear = BufReader::new(bear);
-        let bear = try!(load_obj(bear));
+        let bear = try!(rm.load_obj("rilakkuma"));
 
         let unit = try!(Unit::new(
             facade,


### PR DESCRIPTION
리락쿠마 OBJ 모델 파일을 미리 로드한 후, bincode로 인코딩합니다. 실행할때엔 Wavefront OBJ를 매번 파싱하는 대신, 이 bincode로 인코딩된 모델 파일만 역직렬화시켜서 사용하여, 리소스 로딩속도를 향상시켰습니다.
